### PR TITLE
[4월 1주차/poemnow] book 로직 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,26 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.10.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.14.2</version>
+		</dependency>
+
+		<!-- jackson-databind 라이브러리 추가 -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.14.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/cgm/poemnow/controller/BookController.java
+++ b/src/main/java/com/cgm/poemnow/controller/BookController.java
@@ -8,10 +8,14 @@ import com.cgm.poemnow.service.book.BookService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,7 +26,7 @@ public class BookController {
 
 	@PostMapping("/bookAdd")
 	public ResponseEntity<?> bookAdd(@RequestBody Book bookRequest) {
-		int response = bookService.bookAdd(bookRequest);
+		int response = bookService.addBook(bookRequest);
 		return new ResponseEntity<>(response, HttpStatus.CREATED);
 	}
 
@@ -31,4 +35,25 @@ public class BookController {
 		List<Book> response = bookService.findAllBooks();
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
+
+	@GetMapping("/bookDetail/{id}")
+	public ResponseEntity<Book> bookDetail(@PathVariable("id") int id) {
+		Book response = bookService.findBookById(id);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	// todo book과 poem 연결 테이블까지 적용하는 로직 넣기
+	@PatchMapping("/bookModify")
+	public ResponseEntity<?> bookModify(@RequestParam int id, @RequestParam String title) {
+		Book book = Book.builder().id(id).title(title).build();
+		int response = bookService.modifyBook(book);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	@DeleteMapping("/bookRemove/{id}")
+	public ResponseEntity<?> bookRemove(@PathVariable("id") int id) {
+		int response = bookService.removeBook(id);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
 }

--- a/src/main/java/com/cgm/poemnow/controller/BookController.java
+++ b/src/main/java/com/cgm/poemnow/controller/BookController.java
@@ -3,6 +3,7 @@ package com.cgm.poemnow.controller;
 import java.util.List;
 
 import com.cgm.poemnow.domain.Book;
+import com.cgm.poemnow.domain.BookRequest;
 import com.cgm.poemnow.service.book.BookService;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,50 +11,59 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/book")
 public class BookController {
+
 	@Autowired
 	private BookService bookService;
 
 	@PostMapping("/bookAdd")
-	public ResponseEntity<?> bookAdd(@RequestBody Book bookRequest) {
-		int response = bookService.addBook(bookRequest);
-		return new ResponseEntity<>(response, HttpStatus.CREATED);
+	public ResponseEntity<Object> bookAdd(@RequestBody BookRequest bookRequest) {
+		bookService.addBook(bookRequest);
+		try {
+			return new ResponseEntity<>("시집이 성공적으로 생성됐습니다.", HttpStatus.CREATED);
+		} catch (IllegalArgumentException e) {
+			return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+		} catch (Exception e) {
+			return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+		}
 	}
 
 	@GetMapping(path = "/bookList")
 	public ResponseEntity<List<Book>> bookList() {
-		List<Book> response = bookService.findAllBooks();
-		return new ResponseEntity<>(response, HttpStatus.OK);
+		return new ResponseEntity<>(bookService.findAllBooks(), HttpStatus.OK);
+	}
+
+	@GetMapping(path = "/poemListByBookId/{id}")
+	public ResponseEntity<Object> poemListByBookId(@PathVariable("id") int id) {
+		try {
+			return new ResponseEntity<>(bookService.findPoemsByBookId(id), HttpStatus.OK);
+		} catch (NullPointerException e) {
+			return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+		}
 	}
 
 	@GetMapping("/bookDetail/{id}")
 	public ResponseEntity<Book> bookDetail(@PathVariable("id") int id) {
-		Book response = bookService.findBookById(id);
-		return new ResponseEntity<>(response, HttpStatus.OK);
+		return new ResponseEntity<>(bookService.findBookById(id), HttpStatus.OK);
 	}
 
-	// todo book과 poem 연결 테이블까지 적용하는 로직 넣기
-	@PatchMapping("/bookModify")
-	public ResponseEntity<?> bookModify(@RequestParam int id, @RequestParam String title) {
-		Book book = Book.builder().id(id).title(title).build();
-		int response = bookService.modifyBook(book);
-		return new ResponseEntity<>(response, HttpStatus.OK);
+	@PutMapping("/bookModify")
+	public ResponseEntity<?> bookModify(@RequestBody BookRequest bookRequest) {
+		return new ResponseEntity<>(bookService.modifyBook(bookRequest), HttpStatus.OK);
 	}
 
 	@DeleteMapping("/bookRemove/{id}")
 	public ResponseEntity<?> bookRemove(@PathVariable("id") int id) {
-		int response = bookService.removeBook(id);
-		return new ResponseEntity<>(response, HttpStatus.OK);
+		return new ResponseEntity<>(bookService.removeBook(id), HttpStatus.OK);
 	}
 
 }

--- a/src/main/java/com/cgm/poemnow/controller/BookController.java
+++ b/src/main/java/com/cgm/poemnow/controller/BookController.java
@@ -1,0 +1,34 @@
+package com.cgm.poemnow.controller;
+
+import java.util.List;
+
+import com.cgm.poemnow.domain.Book;
+import com.cgm.poemnow.service.book.BookService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/book")
+public class BookController {
+	@Autowired
+	private BookService bookService;
+
+	@PostMapping("/bookAdd")
+	public ResponseEntity<?> bookAdd(@RequestBody Book bookRequest) {
+		int response = bookService.bookAdd(bookRequest);
+		return new ResponseEntity<>(response, HttpStatus.CREATED);
+	}
+
+	@GetMapping(path = "/bookList")
+	public ResponseEntity<List<Book>> bookList() {
+		List<Book> response = bookService.findAllBooks();
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+}

--- a/src/main/java/com/cgm/poemnow/controller/PoemController.java
+++ b/src/main/java/com/cgm/poemnow/controller/PoemController.java
@@ -3,13 +3,14 @@ package com.cgm.poemnow.controller;
 import java.util.List;
 
 import com.cgm.poemnow.domain.Poem;
-import com.cgm.poemnow.service.PoemService;
+import com.cgm.poemnow.service.poem.PoemService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/poem")
 public class PoemController {
 	@Autowired
 	private PoemService poemService;

--- a/src/main/java/com/cgm/poemnow/controller/PoemController.java
+++ b/src/main/java/com/cgm/poemnow/controller/PoemController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class PoemController {
-	// push test
 	@Autowired
 	private PoemService poemService;
 

--- a/src/main/java/com/cgm/poemnow/controller/PoemController.java
+++ b/src/main/java/com/cgm/poemnow/controller/PoemController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class MainController {
+public class PoemController {
 	@Autowired
 	private PoemService poemService;
 

--- a/src/main/java/com/cgm/poemnow/controller/PoemController.java
+++ b/src/main/java/com/cgm/poemnow/controller/PoemController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class PoemController {
+	// push test
 	@Autowired
 	private PoemService poemService;
 

--- a/src/main/java/com/cgm/poemnow/domain/Book.java
+++ b/src/main/java/com/cgm/poemnow/domain/Book.java
@@ -1,0 +1,23 @@
+package com.cgm.poemnow.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Book {
+
+	private int id;
+	private String title;
+	private String author;
+	private Timestamp created_at;
+	private short published;
+	private Timestamp published_at;
+
+}

--- a/src/main/java/com/cgm/poemnow/domain/Book.java
+++ b/src/main/java/com/cgm/poemnow/domain/Book.java
@@ -16,8 +16,10 @@ public class Book {
 	private int id;
 	private String title;
 	private String author;
-	private Timestamp created_at;
+	private Timestamp createdAt;
 	private short published;
-	private Timestamp published_at;
+	private Timestamp publishedAt;
+	private String outerColor;
+	private String innerColor;
 
 }

--- a/src/main/java/com/cgm/poemnow/domain/BookPoem.java
+++ b/src/main/java/com/cgm/poemnow/domain/BookPoem.java
@@ -1,0 +1,14 @@
+package com.cgm.poemnow.domain;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class BookPoem {
+
+	private int bookId;
+	private int poemId;
+	private int poemOrder;
+
+}

--- a/src/main/java/com/cgm/poemnow/domain/BookRequest.java
+++ b/src/main/java/com/cgm/poemnow/domain/BookRequest.java
@@ -1,0 +1,19 @@
+package com.cgm.poemnow.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BookRequest {
+
+	private Book book;
+	private List<BookPoem> bookPoemList;
+
+}

--- a/src/main/java/com/cgm/poemnow/mapper/BookMapper.java
+++ b/src/main/java/com/cgm/poemnow/mapper/BookMapper.java
@@ -15,4 +15,10 @@ public interface BookMapper {
 
 	List<Book> selectAllBooks();
 
+	Book selectBookById(int id);
+
+	int updateBook(Book book);
+
+	int deleteBook(int id);
+
 }

--- a/src/main/java/com/cgm/poemnow/mapper/BookMapper.java
+++ b/src/main/java/com/cgm/poemnow/mapper/BookMapper.java
@@ -2,16 +2,17 @@ package com.cgm.poemnow.mapper;
 
 import java.util.List;
 
-import com.cgm.poemnow.domain.Poem;
+import com.cgm.poemnow.domain.Book;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @Mapper
-public interface PoemMapper {
+public interface BookMapper {
 
-	List<Poem> poemList();
-	Poem insertPoem(Poem poem);
+	int insertBook(Book book);
+
+	List<Book> selectAllBooks();
 
 }

--- a/src/main/java/com/cgm/poemnow/mapper/BookMapper.java
+++ b/src/main/java/com/cgm/poemnow/mapper/BookMapper.java
@@ -1,8 +1,10 @@
 package com.cgm.poemnow.mapper;
 
 import java.util.List;
+import java.util.Map;
 
 import com.cgm.poemnow.domain.Book;
+import com.cgm.poemnow.domain.Poem;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.springframework.stereotype.Repository;
@@ -13,12 +15,20 @@ public interface BookMapper {
 
 	int insertBook(Book book);
 
+	int insertBookPoem(Map map);
+
 	List<Book> selectAllBooks();
 
+	List<Poem> selectPoemsByBookId(int id);
+
 	Book selectBookById(int id);
+
+	int selectRecentBook();
 
 	int updateBook(Book book);
 
 	int deleteBook(int id);
+
+	int deleteBookPoem(Book book);
 
 }

--- a/src/main/java/com/cgm/poemnow/service/book/BookService.java
+++ b/src/main/java/com/cgm/poemnow/service/book/BookService.java
@@ -6,8 +6,14 @@ import com.cgm.poemnow.domain.Book;
 
 public interface BookService {
 
-	int bookAdd(Book book);
+	int addBook(Book book);
 
 	List<Book> findAllBooks();
+
+	Book findBookById(int id);
+
+	int modifyBook(Book book);
+
+	int removeBook(int id);
 
 }

--- a/src/main/java/com/cgm/poemnow/service/book/BookService.java
+++ b/src/main/java/com/cgm/poemnow/service/book/BookService.java
@@ -3,16 +3,20 @@ package com.cgm.poemnow.service.book;
 import java.util.List;
 
 import com.cgm.poemnow.domain.Book;
+import com.cgm.poemnow.domain.BookRequest;
+import com.cgm.poemnow.domain.Poem;
 
 public interface BookService {
 
-	int addBook(Book book);
+	int addBook(BookRequest bookRequest);
 
 	List<Book> findAllBooks();
 
+	List<Poem> findPoemsByBookId(int id);
+
 	Book findBookById(int id);
 
-	int modifyBook(Book book);
+	int modifyBook(BookRequest bookRequest);
 
 	int removeBook(int id);
 

--- a/src/main/java/com/cgm/poemnow/service/book/BookService.java
+++ b/src/main/java/com/cgm/poemnow/service/book/BookService.java
@@ -1,0 +1,13 @@
+package com.cgm.poemnow.service.book;
+
+import java.util.List;
+
+import com.cgm.poemnow.domain.Book;
+
+public interface BookService {
+
+	int bookAdd(Book book);
+
+	List<Book> findAllBooks();
+
+}

--- a/src/main/java/com/cgm/poemnow/service/book/BookServiceImpl.java
+++ b/src/main/java/com/cgm/poemnow/service/book/BookServiceImpl.java
@@ -1,0 +1,29 @@
+package com.cgm.poemnow.service.book;
+
+import java.util.List;
+
+import com.cgm.poemnow.domain.Book;
+import com.cgm.poemnow.mapper.BookMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class BookServiceImpl implements BookService {
+
+	@Autowired
+	private BookMapper bookMapper;
+
+	@Override
+	public int bookAdd(Book book) {
+		return bookMapper.insertBook(book);
+	}
+
+	@Override
+	public List<Book> findAllBooks() {
+		return bookMapper.selectAllBooks();
+	}
+
+}

--- a/src/main/java/com/cgm/poemnow/service/book/BookServiceImpl.java
+++ b/src/main/java/com/cgm/poemnow/service/book/BookServiceImpl.java
@@ -1,8 +1,13 @@
 package com.cgm.poemnow.service.book;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.cgm.poemnow.domain.Book;
+import com.cgm.poemnow.domain.BookPoem;
+import com.cgm.poemnow.domain.BookRequest;
+import com.cgm.poemnow.domain.Poem;
 import com.cgm.poemnow.mapper.BookMapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,8 +22,21 @@ public class BookServiceImpl implements BookService {
 	private BookMapper bookMapper;
 
 	@Override
-	public int addBook(Book book) {
-		return bookMapper.insertBook(book);
+	public int addBook(BookRequest bookRequest) {
+		Book book = bookRequest.getBook();
+		List<BookPoem> list = bookRequest.getBookPoemList();
+
+		bookMapper.insertBook(book);
+		int bookId = bookMapper.selectRecentBook();
+		Map<String, Object> map = new HashMap<>();
+
+		// list 안에 있는 bookPoem 객체의 요소 bookId에 최근에 들어간 book의 id 넣어줌
+		for (BookPoem bp : list) {
+			bp.setBookId(bookId);
+		}
+		map.put("list", list);
+
+		return bookMapper.insertBookPoem(map);
 	}
 
 	@Override
@@ -27,13 +45,31 @@ public class BookServiceImpl implements BookService {
 	}
 
 	@Override
+	public List<Poem> findPoemsByBookId(int id) { return bookMapper.selectPoemsByBookId(id); }
+
+	@Override
 	public Book findBookById(int id) { return bookMapper.selectBookById(id); }
 
 	@Override
-	public int modifyBook(Book book) { return bookMapper.updateBook(book); }
+	public int modifyBook(BookRequest bookRequest) {
+		Book book = bookRequest.getBook();
+		List<BookPoem> bookPoemList = bookRequest.getBookPoemList();
+
+		Map<String, Object> map = new HashMap<>();
+		map.put("list", bookPoemList);
+
+		bookMapper.updateBook(book);
+		// 해당하는 북 포엠 다 지우고
+		bookMapper.deleteBookPoem(book);
+		// 새로 다시 담기
+		return bookMapper.insertBookPoem(map);
+	}
 
 	@Override
 	public int removeBook(int id) {
+		Book book = new Book();
+		book.setId(id);
+		bookMapper.deleteBookPoem(book);
 		return bookMapper.deleteBook(id);
 	}
 

--- a/src/main/java/com/cgm/poemnow/service/book/BookServiceImpl.java
+++ b/src/main/java/com/cgm/poemnow/service/book/BookServiceImpl.java
@@ -17,13 +17,24 @@ public class BookServiceImpl implements BookService {
 	private BookMapper bookMapper;
 
 	@Override
-	public int bookAdd(Book book) {
+	public int addBook(Book book) {
 		return bookMapper.insertBook(book);
 	}
 
 	@Override
 	public List<Book> findAllBooks() {
 		return bookMapper.selectAllBooks();
+	}
+
+	@Override
+	public Book findBookById(int id) { return bookMapper.selectBookById(id); }
+
+	@Override
+	public int modifyBook(Book book) { return bookMapper.updateBook(book); }
+
+	@Override
+	public int removeBook(int id) {
+		return bookMapper.deleteBook(id);
 	}
 
 }

--- a/src/main/java/com/cgm/poemnow/service/poem/PoemService.java
+++ b/src/main/java/com/cgm/poemnow/service/poem/PoemService.java
@@ -1,9 +1,13 @@
-package com.cgm.poemnow.service;
+package com.cgm.poemnow.service.poem;
 
 import java.util.List;
 
 import com.cgm.poemnow.domain.Poem;
 
 public interface PoemService {
+
 	List<Poem> listPoem();
+
+	Poem addPoem(Poem poemRequest);
+
 }

--- a/src/main/java/com/cgm/poemnow/service/poem/PoemServiceImpl.java
+++ b/src/main/java/com/cgm/poemnow/service/poem/PoemServiceImpl.java
@@ -20,4 +20,10 @@ public class PoemServiceImpl implements PoemService {
 	public List<Poem> listPoem() {
 		return poemMapper.poemList();
 	}
+
+	@Override
+	public Poem addPoem(Poem poem) {
+		return poemMapper.insertPoem(poem);
+	}
+
 }

--- a/src/main/java/com/cgm/poemnow/service/poem/PoemServiceImpl.java
+++ b/src/main/java/com/cgm/poemnow/service/poem/PoemServiceImpl.java
@@ -1,4 +1,4 @@
-package com.cgm.poemnow.service;
+package com.cgm.poemnow.service.poem;
 
 import java.util.List;
 

--- a/src/main/resources/mapper/BookMapper.xml
+++ b/src/main/resources/mapper/BookMapper.xml
@@ -2,39 +2,97 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
 <mapper namespace="com.cgm.poemnow.mapper.BookMapper" >
 
+    <resultMap id="bookMap" type="com.cgm.poemnow.domain.Book">
+        <result column="id" property="id"/>
+        <result column="title" property="title"/>
+        <result column="author" property="author"/>
+        <result column="created_at" property="createdAt" jdbcType="TIMESTAMP"/>
+        <result column="published" property="published"/>
+        <result column="published_at" property="publishedAt"/>
+        <result column="outer_color" property="outerColor"/>
+        <result column="inner_color" property="innerColor"/>
+    </resultMap>
+
+    <select id="selectPoemsByBookId" parameterType="INT" resultType="com.cgm.poemnow.domain.Poem">
+        SELECT DISTINCT
+            bp.poem_order,
+            bp.poem_id id,
+            p.title,
+            p.content,
+            p.author_id,
+            p.created_at,
+            p.updated_at,
+            p.published,
+            p.published_at,
+            p.like_cnt,
+            p.view_cnt,
+            p.unknown
+        FROM book_poem bp, poem p
+        WHERE bp.book_id = #{id} and bp.poem_id = p.id
+        ORDER BY bp.poem_order ASC
+    </select>
+
     <select id="selectAllBooks" resultType="com.cgm.poemnow.domain.Book">
-        SELECT id, title, author FROM book
+        SELECT * from book
     </select>
 
     <insert id="insertBook" parameterType="com.cgm.poemnow.domain.Book">
         INSERT INTO book
             (
              title,
-             author
+             author,
+             outer_color,
+             inner_color
             )
         VALUES
             (
              #{title},
-             #{author}
+             #{author},
+             #{outerColor},
+             #{innerColor}
             )
     </insert>
 
-    <select id="selectBookById" parameterType="int" resultType="com.cgm.poemnow.domain.Book">
-        SELECT id, title, author
+    <insert id="insertBookPoem" parameterType="java.util.Map">
+        INSERT INTO book_poem
+            (
+             book_id,
+             poem_id,
+             poem_order
+            )
+        VALUES
+            <foreach item="item" index="index" collection="list" separator=",">
+                (#{item.bookId}, #{item.poemId}, #{item.poemOrder})
+            </foreach>
+    </insert>
+
+    <select id="selectBookById" parameterType="int" resultMap="bookMap">
+        SELECT *
         FROM book
         WHERE id = #{id}
     </select>
 
-    <insert id="updateBook" parameterType="com.cgm.poemnow.domain.Book">
+    <select id="selectRecentBook" resultType="INT">
+        SELECT MAX(id)
+        FROM book
+    </select>
+
+    <update id="updateBook" parameterType="com.cgm.poemnow.domain.Book">
         UPDATE book
         SET title = #{title}
         WHERE id = #{id}
-    </insert>
+    </update>
 
     <delete id="deleteBook" parameterType="int">
         DELETE
         FROM book
-        WHERE id = #{param1}
+        WHERE id = #{id}
+    </delete>
+
+    <delete id="deleteBookPoem" parameterType="com.cgm.poemnow.domain.Book">
+        DELETE
+        FROM book_poem
+        WHERE book_id = #{id}
     </delete>
 
 </mapper>

--- a/src/main/resources/mapper/BookMapper.xml
+++ b/src/main/resources/mapper/BookMapper.xml
@@ -3,7 +3,7 @@
 <mapper namespace="com.cgm.poemnow.mapper.BookMapper" >
 
     <select id="selectAllBooks" resultType="com.cgm.poemnow.domain.Book">
-        select id, title, author from book <!--(필요한 쿼리문 작성) - 출력-->
+        SELECT id, title, author FROM book
     </select>
 
     <insert id="insertBook" parameterType="com.cgm.poemnow.domain.Book">
@@ -18,5 +18,23 @@
              #{author}
             )
     </insert>
+
+    <select id="selectBookById" parameterType="int" resultType="com.cgm.poemnow.domain.Book">
+        SELECT id, title, author
+        FROM book
+        WHERE id = #{id}
+    </select>
+
+    <insert id="updateBook" parameterType="com.cgm.poemnow.domain.Book">
+        UPDATE book
+        SET title = #{title}
+        WHERE id = #{id}
+    </insert>
+
+    <delete id="deleteBook" parameterType="int">
+        DELETE
+        FROM book
+        WHERE id = #{param1}
+    </delete>
 
 </mapper>

--- a/src/main/resources/mapper/BookMapper.xml
+++ b/src/main/resources/mapper/BookMapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="com.cgm.poemnow.mapper.BookMapper" >
+
+    <select id="selectAllBooks" resultType="com.cgm.poemnow.domain.Book">
+        select id, title, author from book <!--(필요한 쿼리문 작성) - 출력-->
+    </select>
+
+    <insert id="insertBook" parameterType="com.cgm.poemnow.domain.Book">
+        INSERT INTO book
+            (
+             title,
+             author
+            )
+        VALUES
+            (
+             #{title},
+             #{author}
+            )
+    </insert>
+
+</mapper>

--- a/src/main/resources/mapper/PoemMapper.xml
+++ b/src/main/resources/mapper/PoemMapper.xml
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
 <mapper namespace="com.cgm.poemnow.mapper.PoemMapper" >
+
     <select id="poemList" resultType="com.cgm.poemnow.domain.Poem">
-        select * from poem <!--(필요한 쿼리문 작성) - 출력-->
+        select * from poem
     </select>
-<!--    <insert id="insert">-->
-<!--        INSERT INTO dto (-->
-<!--        hit,-->
-<!--        title,-->
-<!--        writedate,-->
-<!--        writer)-->
-<!--        VALUES (-->
-<!--        #{hit},-->
-<!--        #{title},-->
-<!--        #{writeDate},-->
-<!--        #{writer}-->
-<!--        )  &lt;!&ndash;(필요한 쿼리문 작성) -입력&ndash;&gt;-->
-<!--    </insert>-->
+
 </mapper>

--- a/src/test/java/com/cgm/poemnow/PoemnowApplicationTests.java
+++ b/src/test/java/com/cgm/poemnow/PoemnowApplicationTests.java
@@ -1,13 +1,25 @@
 package com.cgm.poemnow;
 
+import com.cgm.poemnow.service.PoemServiceImpl;
+
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class PoemnowApplicationTests {
 
+	@Autowired
+	PoemServiceImpl poemService;
+
 	@Test
 	void contextLoads() {
+	}
+
+	@Test
+	void getPoemList() {
+		String result = poemService.listPoem().toString();
+		System.out.println("result : " + result);
 	}
 
 }

--- a/src/test/java/com/cgm/poemnow/PoemnowApplicationTests.java
+++ b/src/test/java/com/cgm/poemnow/PoemnowApplicationTests.java
@@ -1,6 +1,6 @@
 package com.cgm.poemnow;
 
-import com.cgm.poemnow.service.PoemServiceImpl;
+import com.cgm.poemnow.service.poem.PoemServiceImpl;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,8 +18,8 @@ class PoemnowApplicationTests {
 
 	@Test
 	void getPoemList() {
-		String result = poemService.listPoem().toString();
-		System.out.println("result : " + result);
 	}
+
+
 
 }

--- a/src/test/java/com/cgm/poemnow/controller/BookControllerTest.java
+++ b/src/test/java/com/cgm/poemnow/controller/BookControllerTest.java
@@ -15,6 +15,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -33,8 +35,8 @@ class BookControllerTest {
 	MockMvc mvc;
 
 	@Test
-	@DisplayName("시집 추가 테스트")
-	void bookAdd() throws Exception{
+	@DisplayName("시집 추가 및 리스트 조회 테스트")
+	void bookAddAndBookList() throws Exception{
 
 		// given
 		Book newbook = Book.builder()
@@ -65,7 +67,7 @@ class BookControllerTest {
 		boolean isContained = false;
 		for (JsonElement jsonElement : jsonArray) {
 			Book book = gson.fromJson(jsonElement, Book.class);
-			if(30==(book.getId())) {
+			if(34==(book.getId())) {
 				isContained = true;
 				break;
 			}
@@ -73,4 +75,93 @@ class BookControllerTest {
 		assertThat(isContained).isTrue();
 
 	}
+
+	@Test
+	@DisplayName("시집 id로 조회 테스트")
+	void bookDetailTest() throws Exception {
+
+		// given
+		int id = 3;
+
+		MvcResult mvcResult = mvc.perform(get("/book/bookDetail/" + id))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andReturn();
+
+		String response = mvcResult.getResponse().getContentAsString();
+
+		Gson gson = new Gson();
+		Book selectedBook = gson.fromJson(response, Book.class);
+
+		// 조회된 이름과 비교해줍니다.
+		assertThat(selectedBook.getId()).isEqualTo(3);
+	}
+
+	@Test
+	@DisplayName("시집 수정 및 조회 확인 테스트")
+	void bookUpdateTest() throws Exception {
+
+		// 수정 이전 정보 출력 + 수정 + 수정 후 정보 출력
+
+		// 수정 이전 정보 출력
+		// given
+		int id = 3;
+
+		System.out.println(":::::::::: before update :::::::::");
+
+		mvc.perform(get("/book/bookDetail/" + id))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andReturn();
+
+		// given
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		String newTitle = "수정된 시집 제목";
+		params.add("title", newTitle);
+		params.add("id", String.valueOf(3));
+		mvc.perform(patch("/book/bookModify")
+						.params(params))
+				.andExpect(status().isOk());
+
+		mvc.perform(get("/book/bookDetail/" + id))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andReturn();
+
+	}
+
+	@Test
+	@DisplayName("시집 삭제 및 데이터 개수 변화 확인 테스트")
+	void bookRemoveTest() throws Exception {
+
+		// 전체조회하여 첫번째 데이터를 꺼내옵니다.
+		MvcResult mvcResult1 = mvc.perform(get("/book/bookList"))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andReturn();
+
+		String jsonResult = mvcResult1.getResponse().getContentAsString();
+
+		JsonParser jsonParser = new JsonParser();
+		JsonArray jsonArray = jsonParser.parse(jsonResult).getAsJsonArray();
+
+		int id = jsonArray.get(0).getAsJsonObject().get("id").getAsInt();
+		int size = jsonArray.size();
+
+		// 첫번째 데이터를 삭제합니다.
+		mvc.perform(delete("/book/bookRemove/"+id))
+				.andExpect(status().isOk());
+
+		MvcResult mvcResult2 = mvc.perform(get("/book/bookList"))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andReturn();
+
+		String jsonResult2 = mvcResult2.getResponse().getContentAsString();
+
+		// 전체 데이터갯수가 한개 줄었나 확인해줍니다.
+		assertThat(jsonParser.parse(jsonResult2).getAsJsonArray().size()).isEqualTo(size-1);
+
+	}
+
 }

--- a/src/test/java/com/cgm/poemnow/controller/BookControllerTest.java
+++ b/src/test/java/com/cgm/poemnow/controller/BookControllerTest.java
@@ -1,0 +1,76 @@
+package com.cgm.poemnow.controller;
+
+import com.cgm.poemnow.domain.Book;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class BookControllerTest {
+
+	@Autowired
+	BookController bookController;
+
+	@Autowired
+	MockMvc mvc;
+
+	@Test
+	@DisplayName("시집 추가 테스트")
+	void bookAdd() throws Exception{
+
+		// given
+		Book newbook = Book.builder()
+				.title("안녕하세요! 적당히 바람이 시원해 기분이 너무 좋아요! 유후!")
+				.author("박미정")
+				.build();
+
+		String jsonData = new Gson().toJson(newbook);
+
+		mvc.perform(post("http://127.0.0.1:8080/book/bookAdd")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonData))
+				.andExpect(status().isCreated()); // 아래에서 바로 조회까지 할테니 상태코드만 확인
+
+		// 저장된 데이터를 단건으로 조회해도 되지만
+		// 그냥 전체 조회 로직 테스트
+
+		MvcResult mvcResult = mvc.perform(get("http://127.0.0.1:8080/book/bookList"))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andReturn();
+
+		String jsonResult = mvcResult.getResponse().getContentAsString();
+
+		JsonParser jsonParser = new JsonParser();
+		JsonArray jsonArray = jsonParser.parse(jsonResult).getAsJsonArray();
+		Gson gson = new GsonBuilder().disableHtmlEscaping().setDateFormat("yy-MM-dd hh;mm:ss").create();
+		boolean isContained = false;
+		for (JsonElement jsonElement : jsonArray) {
+			Book book = gson.fromJson(jsonElement, Book.class);
+			if(30==(book.getId())) {
+				isContained = true;
+				break;
+			}
+		}
+		assertThat(isContained).isTrue();
+
+	}
+}


### PR DESCRIPTION
# 개요

- 외부 API endpoint 연결 고민
- 데이터베이스 변경 사항
- book 로직 구현(시집 만들기, 수정, 삭제, 상세보기, 전체 리스트)
<br><br><br>

## 외부 API endpoint 연결 고민
시집 색상 선택 시 react API 'react-colorful' 적용( 본 이슈의 '데이터베이스 변경 사항' 2단계 참고 )

<br><br><br>

## 데이터베이스 변경 사항


### 1) 시집 색깔 받아오기 template 구현
`1단계`: 자바로 구현 가능한 api 찾기
- 너무 옛날 글 밖에 없어서 포기
- -> 프론트로 구현 가능한 부분으로 전환

`2단계`: react로 구현 가능한 api 찾기
- 'color picker' : user에게 색상 선택을 할 수 있도록 도와주는 기능
- [8 Best React Color Picker Library 2023](https://openbase.com/categories/js/best-react-color-picker-libraries?vs=react-colorful%2Creact-color%2Crc-color-picker) - 딱 맞는 글 발견
- 이 중 react-colorful이 다운로드 수 & 깃허브 수가 가장 많음 -> 선택
- [리액트 컬러피커 종류별 예제 링크](https://edupala.com/best-react-color-picker-and-how-to-implement-it/)
- [react-colorful 예제 링크](https://onu0624.tistory.com/128) : 여기에 따르면 색상을 #aabbcc 이런 식으로 받아옴

`3단계`: 'book' 테이블에 border_color, inner_color 컬럼 추가 [github 적용 링크](https://github.com/poemnow/poemnow/issues/1#issuecomment-1486215159)

~~기능 아이디어: 색상 고르기 힘들면 랜덤으로 정해주는 기능 있으면 좋긴 할 것 같다.~~
<br>

### 2) 시집-좋아요 테이블 생성
[github 적용 링크](https://github.com/poemnow/poemnow/issues/1#issuecomment-1500822270)

<br>

### 3) book 테이블에 익명 여부 컬럼 추가 및 작가 이름 VARCHAR(100)->VARCHAR(64) 변경
- 특정 유저가 가지고 있는 시집 목록 조회하려면 시집과 유저를 연결하는 테이블이 있거나 시집마다 유저의 정보가 있어야 하는데 현재 시인의 이름만 있다. 유저의 닉네임이 64자인 것이지만 기존 book의 시인 이름 길이가 100이라서 바꿔 줌
- 의논거리에 유저 이름으로 조회하는 메서드 필요할 것 같아 추가 [링크](https://www.notion.so/6de0122bcf5742fe9278db8c74e3c5e5?v=fd78eea39f4c4094be1e20c888500c3b)

<br><br>

## book 로직 구현 (시집 만들기, 수정, 삭제, 상세보기, 전체 리스트)


### test code -> timestamp 오류 관련 => gson 문제




