### PR TITLE
[4월 1주차/poemnow] comment 로직 구현 

### DIFF
--- a/src/main/java/com/cgm/poemnow/controller/CommentController.java
+++ b/src/main/java/com/cgm/poemnow/controller/CommentController.java
@@ -41,4 +41,16 @@ public class CommentController {
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
+	@PutMapping("/userCommentRemove")
+	public ResponseEntity<?> userCommentRemove(@RequestBody int userId) {
+		int response = commentService.removeCommentsByUserId(userId);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	@GetMapping("/myComments")
+	public ResponseEntity<List<Comment>> myCommentList(@RequestParam(value="peomId") int poemId){
+		List<Comment> response = commentService.findCommentsOfThePoem(poemId);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
 }

--- a/src/main/java/com/cgm/poemnow/controller/CommentController.java
+++ b/src/main/java/com/cgm/poemnow/controller/CommentController.java
@@ -29,16 +29,15 @@ public class CommentController {
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
-	@PatchMapping("/commentModify")
-	public ResponseEntity<?> commentModify(@RequestParam int id, @RequestParam String content) {
-		Comment comment = Comment.builder().id(id).content(content).build();
-		int response = commentService.modifyComment(comment);
+	@PutMapping("/commentModify")
+	public ResponseEntity<?> commentModify(@RequestBody Comment commentRequest) {
+		int response = commentService.modifyComment(commentRequest);
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
-	@DeleteMapping("/commentRemove/{id}")
-	public ResponseEntity<?> commentRemove(@PathVariable("id") int id) {
-		int response = commentService.removeComment(id);
+	@PutMapping("/commentRemove")
+	public ResponseEntity<?> commentRemove(@RequestBody Comment commentRequest) {
+		int response = commentService.removeComment(commentRequest);
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 

--- a/src/main/java/com/cgm/poemnow/controller/CommentController.java
+++ b/src/main/java/com/cgm/poemnow/controller/CommentController.java
@@ -1,0 +1,45 @@
+package com.cgm.poemnow.controller;
+
+import java.util.List;
+
+import com.cgm.poemnow.domain.Comment;
+import com.cgm.poemnow.service.comment.CommentService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/comment")
+public class CommentController {
+
+	@Autowired
+	private CommentService commentService;
+
+	@PostMapping("/commentAdd")
+	public ResponseEntity<?> commentAdd(@RequestBody Comment commentRequest) {
+		int response = commentService.addComment(commentRequest);
+		return new ResponseEntity<>(response, HttpStatus.CREATED);
+	}
+
+	@GetMapping("/commentList")
+	public ResponseEntity<List<Comment>> commentList() {
+		List<Comment> response = commentService.findAllComments();
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	@PatchMapping("/commentModify")
+	public ResponseEntity<?> commentModify(@RequestParam int id, @RequestParam String content) {
+		Comment comment = Comment.builder().id(id).content(content).build();
+		int response = commentService.modifyComment(comment);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	@DeleteMapping("/commentRemove/{id}")
+	public ResponseEntity<?> commentRemove(@PathVariable("id") int id) {
+		int response = commentService.removeComment(id);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+}

--- a/src/main/java/com/cgm/poemnow/domain/Comment.java
+++ b/src/main/java/com/cgm/poemnow/domain/Comment.java
@@ -1,0 +1,23 @@
+package com.cgm.poemnow.domain;
+
+import jdk.jshell.Snippet;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Comment {
+
+	private int id;
+	private String content;
+	private int userId;
+	private int poemId;
+	private String createdAt;
+	private String updatedAt;
+	private boolean deleted;
+
+}

--- a/src/main/java/com/cgm/poemnow/mapper/CommentMapper.java
+++ b/src/main/java/com/cgm/poemnow/mapper/CommentMapper.java
@@ -18,4 +18,8 @@ public interface CommentMapper {
 
 	int deleteComment(Comment comment);
 
+	List<Comment> selectCommentsOfThePoem(int poemId);
+
+	int deleteCommentsByUserId(int userId);
+
 }

--- a/src/main/java/com/cgm/poemnow/mapper/CommentMapper.java
+++ b/src/main/java/com/cgm/poemnow/mapper/CommentMapper.java
@@ -16,5 +16,6 @@ public interface CommentMapper {
 
 	int updateComment(Comment comment);
 
-	int deleteComment(int id);
+	int deleteComment(Comment comment);
+
 }

--- a/src/main/java/com/cgm/poemnow/mapper/CommentMapper.java
+++ b/src/main/java/com/cgm/poemnow/mapper/CommentMapper.java
@@ -1,0 +1,20 @@
+package com.cgm.poemnow.mapper;
+
+import com.cgm.poemnow.domain.Comment;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Mapper
+@Repository
+public interface CommentMapper {
+	int insertComment(Comment comment);
+
+	List<Comment> selectAllComments();
+
+	int updateComment(Comment comment);
+
+	int deleteComment(int id);
+}

--- a/src/main/java/com/cgm/poemnow/service/comment/CommentService.java
+++ b/src/main/java/com/cgm/poemnow/service/comment/CommentService.java
@@ -12,6 +12,6 @@ public interface CommentService {
 
 	int modifyComment(Comment comment);
 
-	int removeComment(int id);
+	int removeComment(Comment comment);
 
 }

--- a/src/main/java/com/cgm/poemnow/service/comment/CommentService.java
+++ b/src/main/java/com/cgm/poemnow/service/comment/CommentService.java
@@ -1,0 +1,17 @@
+package com.cgm.poemnow.service.comment;
+
+import com.cgm.poemnow.domain.Comment;
+
+import java.util.List;
+
+public interface CommentService {
+
+	int addComment(Comment comment);
+
+	List<Comment> findAllComments();
+
+	int modifyComment(Comment comment);
+
+	int removeComment(int id);
+
+}

--- a/src/main/java/com/cgm/poemnow/service/comment/CommentService.java
+++ b/src/main/java/com/cgm/poemnow/service/comment/CommentService.java
@@ -14,4 +14,8 @@ public interface CommentService {
 
 	int removeComment(Comment comment);
 
+	List<Comment> findCommentsOfThePoem(int poemId);
+
+	int removeCommentsByUserId(int userId);
+
 }

--- a/src/main/java/com/cgm/poemnow/service/comment/CommentServiceImpl.java
+++ b/src/main/java/com/cgm/poemnow/service/comment/CommentServiceImpl.java
@@ -35,4 +35,13 @@ public class CommentServiceImpl implements CommentService{
 		return commentMapper.deleteComment(comment);
 	}
 
+	@Override
+	public List<Comment> findCommentsOfThePoem(int poemId){
+		return commentMapper.selectCommentsOfThePoem(poemId);
+	}
+	@Override
+	public int removeCommentsByUserId(int userId) {
+		return commentMapper.deleteCommentsByUserId(userId);
+	}
+
 }

--- a/src/main/java/com/cgm/poemnow/service/comment/CommentServiceImpl.java
+++ b/src/main/java/com/cgm/poemnow/service/comment/CommentServiceImpl.java
@@ -31,7 +31,8 @@ public class CommentServiceImpl implements CommentService{
 	}
 
 	@Override
-	public int removeComment(int id) {
-		return commentMapper.deleteComment(id);
+	public int removeComment(Comment comment) {
+		return commentMapper.deleteComment(comment);
 	}
+
 }

--- a/src/main/java/com/cgm/poemnow/service/comment/CommentServiceImpl.java
+++ b/src/main/java/com/cgm/poemnow/service/comment/CommentServiceImpl.java
@@ -1,0 +1,37 @@
+package com.cgm.poemnow.service.comment;
+
+import com.cgm.poemnow.domain.Comment;
+import com.cgm.poemnow.mapper.CommentMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class CommentServiceImpl implements CommentService{
+
+	@Autowired
+	private CommentMapper commentMapper;
+
+	@Override
+	public int addComment(Comment comment) {
+		return commentMapper.insertComment(comment);
+	}
+
+	@Override
+	public List<Comment> findAllComments() {
+		return commentMapper.selectAllComments();
+	}
+
+	@Override
+	public int modifyComment(Comment comment) {
+		return commentMapper.updateComment(comment);
+	}
+
+	@Override
+	public int removeComment(int id) {
+		return commentMapper.deleteComment(id);
+	}
+}

--- a/src/main/resources/mapper/CommentMapper.xml
+++ b/src/main/resources/mapper/CommentMapper.xml
@@ -2,6 +2,16 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
 <mapper namespace="com.cgm.poemnow.mapper.CommentMapper" >
 
+    <resultMap id="commentMap" type="com.cgm.poemnow.domain.Comment">
+        <result column="id" property="id"/>
+        <result column="content" property="content"/>
+        <result column="user_id" property="userId"/>
+        <result column="poem_id" property="poemId"/>
+        <result column="created_at" property="createdAt"/>
+        <result column="updated_at" property="updatedAt"/>
+        <result column="deleted" property="deleted"/>
+    </resultMap>
+
     <insert id="insertComment" parameterType="com.cgm.poemnow.domain.Comment">
         INSERT INTO comment
             (
@@ -21,21 +31,21 @@
             )
     </insert>
 
-    <select id="selectAllComments" resultType="com.cgm.poemnow.domain.Comment">
-        SELECT c.id, c.content, c.created_at, c.updated_at, u.user_nickname
+    <select id="selectAllComments" resultMap="commentMap">
+        SELECT c.id, c.content, c.created_at, c.updated_at, u.user_nickname, c.deleted
         FROM comment c
         INNER JOIN user u ON c.user_id = u.id
     </select>
 
     <update id="updateComment" parameterType="com.cgm.poemnow.domain.Comment">
         UPDATE comment
-        SET content = #{content}, updated_at = #{updatedAt}
+        SET content = #{content}, updated_at = CURRENT_TIME()
         WHERE id = #{id}
     </update>
 
-    <update id="deleteComment" parameterType="int">
+    <update id="deleteComment" parameterType="com.cgm.poemnow.domain.Comment">
         UPDATE comment
-        SET deleted = TRUE
+        SET deleted = 1
         WHERE id = #{id}
     </update>
 

--- a/src/main/resources/mapper/CommentMapper.xml
+++ b/src/main/resources/mapper/CommentMapper.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="com.cgm.poemnow.mapper.CommentMapper" >
+
+    <insert id="insertComment" parameterType="com.cgm.poemnow.domain.Comment">
+        INSERT INTO comment
+            (
+            content,
+            user_id,
+            poem_id,
+            created_at,
+            deleted
+            )
+        VALUES
+            (
+            #{content},
+            #{userId},
+            #{poemId},
+            CURRENT_TIME(),
+            FALSE
+            )
+    </insert>
+
+    <select id="selectAllComments" resultType="com.cgm.poemnow.domain.Comment">
+        SELECT c.id, c.content, c.created_at, c.updated_at, u.user_nickname
+        FROM comment c
+        INNER JOIN user u ON c.user_id = u.id
+    </select>
+
+    <update id="updateComment" parameterType="com.cgm.poemnow.domain.Comment">
+        UPDATE comment
+        SET content = #{content}, updated_at = #{updatedAt}
+        WHERE id = #{id}
+    </update>
+
+    <update id="deleteComment" parameterType="int">
+        UPDATE comment
+        SET deleted = TRUE
+        WHERE id = #{id}
+    </update>
+
+</mapper>

--- a/src/main/resources/mapper/CommentMapper.xml
+++ b/src/main/resources/mapper/CommentMapper.xml
@@ -32,9 +32,18 @@
     </insert>
 
     <select id="selectAllComments" resultMap="commentMap">
-        SELECT c.id, c.content, c.created_at, c.updated_at, u.user_nickname, c.deleted
+        SELECT *
         FROM comment c
-        INNER JOIN user u ON c.user_id = u.id
+        LEFT JOIN user u ON c.user_id = u.id
+        WHERE c.user_id IS NOT NULL
+    </select>
+
+    <select id="selectCommentsOfThePoem" parameterType = "int" resultMap="commentMap">
+        SELECT *
+        FROM comment c
+        LEFT JOIN poem p ON c.poem_id = p.id
+        LEFT JOIN user u ON c.user_id = u.id
+        WHERE c.deleted = false AND c.poem_id = #{poemId} AND u.id IS NOT NULL AND p.id IS NOT NULL
     </select>
 
     <update id="updateComment" parameterType="com.cgm.poemnow.domain.Comment">
@@ -47,6 +56,10 @@
         UPDATE comment
         SET deleted = 1
         WHERE id = #{id}
+    </update>
+
+    <update id="deleteCommentsByUserId" parameterType="int">
+        UPDATE comment SET deleted = 1 WHERE user_id = #{userId}
     </update>
 
 </mapper>

--- a/src/test/java/com/cgm/poemnow/controller/CommentControllerTest.java
+++ b/src/test/java/com/cgm/poemnow/controller/CommentControllerTest.java
@@ -6,6 +6,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -34,11 +36,11 @@ class CommentControllerTest {
 
 	@Test
 	@DisplayName("댓글 추가 및 리스트 조회 테스트")
-	void commentAddAndBookList() throws Exception{
+	void commentAddAndCommentList() throws Exception{
 		Comment newcomment = Comment.builder()
-			.content("Test Comment")
+			.content("새로운 댓글 추가입니다.")
 			.userId(1)
-			.poemId(1)
+			.poemId(2)
 			.build();
 
 		String jsonData = new Gson().toJson(newcomment);
@@ -61,12 +63,84 @@ class CommentControllerTest {
 		boolean isContained = false;
 		for (JsonElement jsonElement : jsonArray) {
 			Comment comment = gson.fromJson(jsonElement, Comment.class);
-			if(2==(comment.getId())) {
+			if(20==(comment.getId())) {
 				isContained = true;
 				break;
 			}
 		}
 		assertThat(isContained).isTrue();
+
+	}
+
+	@Test
+	@DisplayName("댓글 수정 및 조회 확인 테스트")
+	public void commentModifyTest() throws Exception {
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		int id = 8;
+
+		//리스트를 전체 가져와서, 리스트에서 포문 돌려서 아이디 같은애를 찾아서 값이 바뀐지본다.
+		mvc.perform(get("/comment/commentList"))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andExpect(jsonPath("$.[?(@.id == 8)]").exists())
+				.andReturn();
+
+		System.out.println("--------------------수정 전------------------------- ");
+
+		String newContent = "완전완전완전완전 새로운 댓글 내용";
+
+		Comment newComment = new Comment();
+		newComment.setId(id);
+		newComment.setContent(newContent);
+
+		// 수정 요청 보냄
+		mvc.perform(put("/comment/commentModify/")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(newComment)))
+				.andExpect(status().isOk());
+
+		System.out.println("--------------------수정 후------------------------- ");
+
+		// 수정한 댓글이 맞는지 확인
+		mvc.perform(get("/comment/commentList"))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andExpect(jsonPath("$.[?(@.id == 8)].content").value(newContent));
+
+	}
+
+	@Test
+	@DisplayName("댓글 삭제 및 조회 확인 테스트")
+	public void commentRemoveTest() throws Exception {
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		int id = 10;
+
+		// 댓글 삭제 전 리스트에서 확인
+		mvc.perform(get("/comment/commentList"))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andExpect(jsonPath("$.[?(@.id == 10)]").exists())
+				.andReturn();
+
+		Comment newComment = new Comment();
+		newComment.setId(id);
+		newComment.setDeleted(true);
+
+		// 댓글 삭제 요청
+		mvc.perform(put("/comment/commentRemove")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(newComment)))
+				.andExpect(status().isOk());
+
+		// 댓글 삭제 후 리스트에서 확인
+		mvc.perform(get("/comment/commentList"))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andExpect(jsonPath("$.[?(@.id == 10)].deleted").value(true));
 
 	}
 

--- a/src/test/java/com/cgm/poemnow/controller/CommentControllerTest.java
+++ b/src/test/java/com/cgm/poemnow/controller/CommentControllerTest.java
@@ -1,0 +1,75 @@
+package com.cgm.poemnow.controller;
+
+import com.cgm.poemnow.domain.Comment;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CommentControllerTest {
+
+	@Autowired
+	CommentController commentController;
+
+	@Autowired
+	MockMvc mvc;
+
+	@Test
+	@DisplayName("댓글 추가 및 리스트 조회 테스트")
+	void commentAddAndBookList() throws Exception{
+		Comment newcomment = Comment.builder()
+			.content("Test Comment")
+			.userId(1)
+			.poemId(1)
+			.build();
+
+		String jsonData = new Gson().toJson(newcomment);
+
+		mvc.perform(post("http://127.0.0.1:8080/comment/commentAdd")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonData))
+				.andExpect(status().isCreated());
+
+		MvcResult mvcResult =mvc.perform(get("http://127.0.0.1:8080/comment/commentList"))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andReturn();
+
+		String jsonResult = mvcResult.getResponse().getContentAsString();
+
+		JsonParser jsonParser = new JsonParser();
+		JsonArray jsonArray = jsonParser.parse(jsonResult).getAsJsonArray();
+		Gson gson = new GsonBuilder().disableHtmlEscaping().setDateFormat("yy-MM-dd hh;mm:ss").create();
+		boolean isContained = false;
+		for (JsonElement jsonElement : jsonArray) {
+			Comment comment = gson.fromJson(jsonElement, Comment.class);
+			if(2==(comment.getId())) {
+				isContained = true;
+				break;
+			}
+		}
+		assertThat(isContained).isTrue();
+
+	}
+
+}
+
+

--- a/src/test/java/com/cgm/poemnow/controller/CommentControllerTest.java
+++ b/src/test/java/com/cgm/poemnow/controller/CommentControllerTest.java
@@ -1,11 +1,12 @@
 package com.cgm.poemnow.controller;
-
 import com.cgm.poemnow.domain.Comment;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.DisplayName;
@@ -13,9 +14,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -142,6 +148,48 @@ class CommentControllerTest {
 				.andDo(print())
 				.andExpect(jsonPath("$.[?(@.id == 10)].deleted").value(true));
 
+	}
+
+	@Test
+	@DisplayName("user_id로 삭제 테스트")
+	public void commentRemoveByUserIdTest() throws Exception {
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		int userId = 1;
+
+		// 댓글 삭제 전 리스트에서 확인
+		mvc.perform(put("/comment/userCommentRemove")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(String.valueOf(userId)))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andReturn();
+
+
+		// 댓글 삭제 후 리스트에서 확인
+		mvc.perform(get("/comment/commentList"))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andReturn();
+
+	}
+
+	@Test
+	@DisplayName("poem_id로 조회 테스트")
+	public void myCommentListTest() throws Exception {
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+//		int poemId = 2;
+
+
+		// 댓글 삭제 전 리스트에서 확인
+		mvc.perform(get("http://localhost:8080/comment/myComments?peomId=2")
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andReturn();
 	}
 
 }


### PR DESCRIPTION
# 개요

- comment 로직 구현(댓글 추가, 댓글 리스트, 댓글 수정, 댓글 삭제)
- 댓글 비동기 방식으로 보여줄 것
- 외부 API
- comment_like table 만듦

### 4.25 변동사항
- user가 null일 경우 comment를 받아오지 않는 로직 추가
- poem_id로 comment의 리스트를 반환하는 로직 추가
- user_id로 해당 유저의 모든 comment를 삭제하는 로직 추가
<br><br><br>
## comment 로직 구현
### 1)insertComment
-  created_at   updated_at   deleted  세개 테이블은 자동으로 생성된다. insert 해줄 필요 없음.
-  content,  user_id, poem_id  insert
`논의`  testcode는??

### 2)selectAllComments
`논의` 날짜는 created 디폴트, updated로 덮어쓰는 로직

### 3)updateComment
`논의`  comment 테이블의 content를 수정한다. 수정 시간도 자동으로 변경되어야 한다.


### 4)deleteComment
- 삭제는 커멘트 테이블의 deleted 칼럼의 트루 폴스 update 로직으로 바꿔준다. (update로 처리)

<br><br>

## 댓글 비동기방식
https://and-some.tistory.com/m/813
### 1) 댓글을 바로 노출 or 댓글 창 눌렀을 때 노출 정하기
- 대부분 댓글 창 눌렀을 때 노출이 많음 (네이버블로그, 브런치)

### 2) url 매핑을 어떻게 할 것인가??
- https://poemnow.com/게시글id
- https://poemnow.com/게시글id/comment
- https://poemnow.com/comment/게시글id
`수정 삭제` 
- https://poemnow.com/게시글id/comment/댓글id

### 3) 비동기 방식으로 

<br><br>

## 외부 API
- Google Translate API : 다국어 지원이 필요한 경우, 구글 번역 API를 활용하여 댓글 번역 기능을 추가할 수 있습니다.
- 꼭 필요한 외부 API는 없는듯해요