### PR TITLE
[5월 1주차/poemnow] 소셜로그인(카카오) endpoint 생성

### DIFF
--- a/src/main/java/com/cgm/poemnow/controller/KakaoController.java
+++ b/src/main/java/com/cgm/poemnow/controller/KakaoController.java
@@ -1,0 +1,52 @@
+package com.cgm.poemnow.controller;
+
+import com.cgm.poemnow.domain.User;
+import com.cgm.poemnow.service.KaKaoLoginService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/login")
+public class KakaoController {
+
+	@Autowired
+	private KaKaoLoginService kaKaoLoginService;
+
+	@GetMapping(value = "/oauth")
+	public void kakaoConnect(HttpServletResponse response) throws IOException {
+		StringBuffer url = new StringBuffer();
+		url.append("https://kauth.kakao.com/oauth/authorize?");
+		url.append("client_id=" + "053162a8f6b7ba902d0d94786b63a656");
+		url.append("&redirect_uri=http://localhost:8080/login/kakaoCallback");
+		url.append("&response_type=code");
+		response.sendRedirect(String.valueOf(url));
+	}
+
+	@GetMapping(path = "/kakaoCallback")
+	public ResponseEntity<String> kakaoCallback(@RequestParam String code, HttpSession session) {
+
+		String response = "";
+		String token = kaKaoLoginService.getKakaoAccessToken(code);
+		String id = kaKaoLoginService.createKakaoUser(token);
+		response = id;
+		User user = kaKaoLoginService.getUser(id);
+		if(user == null){
+			//회원가입 페이지로 보내!!
+			return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+		}else{
+			session.setAttribute("loginUser" , user);
+			//메인으로 보내!!
+			return new ResponseEntity<>(response, HttpStatus.OK);
+		}
+	}
+
+}

--- a/src/main/java/com/cgm/poemnow/mapper/KakaoLoginMapper.java
+++ b/src/main/java/com/cgm/poemnow/mapper/KakaoLoginMapper.java
@@ -1,0 +1,13 @@
+package com.cgm.poemnow.mapper;
+
+import com.cgm.poemnow.domain.User;
+import org.apache.ibatis.annotations.Mapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Mapper
+public interface KakaoLoginMapper {
+
+	User getUser(String id);
+
+}

--- a/src/main/java/com/cgm/poemnow/service/KaKaoLoginService.java
+++ b/src/main/java/com/cgm/poemnow/service/KaKaoLoginService.java
@@ -1,0 +1,13 @@
+package com.cgm.poemnow.service;
+
+import com.cgm.poemnow.domain.User;
+
+public interface KaKaoLoginService {
+
+	String getKakaoAccessToken (String code);
+
+	String createKakaoUser(String token);
+
+	User getUser(String id);
+
+}

--- a/src/main/java/com/cgm/poemnow/service/KakaoLoginServiceImpl.java
+++ b/src/main/java/com/cgm/poemnow/service/KakaoLoginServiceImpl.java
@@ -1,0 +1,132 @@
+package com.cgm.poemnow.service;
+
+import com.cgm.poemnow.domain.User;
+import com.cgm.poemnow.mapper.KakaoLoginMapper;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+@Service
+@Transactional
+public class KakaoLoginServiceImpl implements KaKaoLoginService {
+
+	@Autowired
+	private KakaoLoginMapper kakaoLoginMapper;
+
+	public String getKakaoAccessToken (String code) {
+		String access_Token = "";
+		String refresh_Token = "";
+		String reqURL = "https://kauth.kakao.com/oauth/token";
+
+		try {
+			URL url = new URL(reqURL);
+			HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+			//POST 요청을 위해 기본값이 false인 setDoOutput을 true로
+			conn.setRequestMethod("POST");
+			conn.setDoOutput(true);
+
+			//POST 요청에 필요로 요구하는 파라미터 스트림을 통해 전송
+			BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
+			StringBuilder sb = new StringBuilder();
+			sb.append("grant_type=authorization_code");
+			sb.append("&client_id=053162a8f6b7ba902d0d94786b63a656"); // TODO REST_API_KEY 입력
+			sb.append("&redirect_uri=http://localhost:8080/login/kakaoCallback"); // TODO 인가코드 받은 redirect_uri 입력
+			sb.append("&code=" + code);
+			bw.write(sb.toString());
+			bw.flush();
+
+			//결과 코드가 200이라면 성공
+			int responseCode = conn.getResponseCode();
+			//System.out.println("responseCode : " + responseCode);
+
+			//요청을 통해 얻은 JSON타입의 Response 메세지 읽어오기
+			BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+			String line = "";
+			String result = "";
+
+			while ((line = br.readLine()) != null) {
+				result += line;
+			}
+			//System.out.println("response body : " + result);
+
+			//Gson 라이브러리에 포함된 클래스로 JSON파싱 객체 생성
+			JsonParser parser = new JsonParser();
+			JsonElement element = parser.parse(result);
+
+			access_Token = element.getAsJsonObject().get("access_token").getAsString();
+			refresh_Token = element.getAsJsonObject().get("refresh_token").getAsString();
+
+			//System.out.println("access_token : " + access_Token);
+			//System.out.println("refresh_token : " + refresh_Token);
+
+			br.close();
+			bw.close();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		return access_Token;
+	}
+
+	public String createKakaoUser(String token) {
+		String id = "";
+		String reqURL = "https://kapi.kakao.com/v2/user/me";
+
+		//access_token을 이용하여 사용자 정보 조회
+		try {
+			URL url = new URL(reqURL);
+			HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+			conn.setRequestMethod("POST");
+			conn.setDoOutput(true);
+			conn.setRequestProperty("Authorization", "Bearer " + token); //전송할 header 작성, access_token전송
+
+			//결과 코드가 200이라면 성공
+			int responseCode = conn.getResponseCode();
+			//System.out.println("responseCode : " + responseCode);
+
+			//요청을 통해 얻은 JSON타입의 Response 메세지 읽어오기
+			BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+			String line = "";
+			String result = "";
+
+			while ((line = br.readLine()) != null) {
+				result += line;
+			}
+			//System.out.println("response body : " + result);
+
+			//Gson 라이브러리로 JSON파싱
+			JsonParser parser = new JsonParser();
+			JsonElement element = parser.parse(result);
+
+			id = element.getAsJsonObject().get("id").getAsString();
+			boolean hasEmail = element.getAsJsonObject().get("kakao_account").getAsJsonObject().get("has_email").getAsBoolean();
+			String email = "";
+			if(hasEmail){
+				email = element.getAsJsonObject().get("kakao_account").getAsJsonObject().get("email").getAsString();
+			}
+
+			//System.out.println("id : " + id);
+			//System.out.println("email : " + email);
+
+			br.close();
+
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return id;
+	}
+
+	@Override
+	public User getUser(String id) {
+		return kakaoLoginMapper.getUser(id);
+	}
+
+}

--- a/src/main/resources/mapper/KakaoLoginMapper.xml
+++ b/src/main/resources/mapper/KakaoLoginMapper.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="com.cgm.poemnow.mapper.KakaoLoginMapper" >
+    <select id="getUser" parameterType="String" resultType="com.cgm.poemnow.domain.User">
+        SELECT * FROM user
+        WHERE kakao_id = #{id};
+    </select>
+</mapper>


### PR DESCRIPTION
### 카카오 로그인 구현
1. 카카오로그인 구현 하였습니다. 이미 가입된 회원이면 session에 해당 유저 정보 넣었습니다.
2. 메인페이지로 redirect 시키는 작업은 추후 구현해야 합니다.